### PR TITLE
chore: add -T option to docker compose run command

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,7 +3,7 @@
 #
 # This script simply executes a provided JavaScript test using
 # the local environment established with the `docker-compose`.
-# 
+#
 # Each execution is provided a unique tag to differentiate
 # discrete test runs within the Grafana dashboard.
 #
@@ -18,4 +18,4 @@ fi
 SCRIPT_NAME=$1
 TAG_NAME="$(basename -s .js $SCRIPT_NAME)-$(date +%s)"
 
-docker-compose run --rm k6 run -<$SCRIPT_NAME --tag testid=$TAG_NAME
+docker-compose run --rm -T k6 run -<$SCRIPT_NAME --tag testid=$TAG_NAME


### PR DESCRIPTION
this fix this error
![image](https://user-images.githubusercontent.com/443948/184539689-9cda8f5e-fa1f-4f50-a40f-8969319b9afb.png)

What is “tty: true”?
If you write “tty: true” in the docker-compose.yml, you will be able to “keep the container running”.

This is the same as writing -t in the docker command.https://docs.docker.com/engine/reference/run/#foreground