### PR TITLE
doc: replace scripts by samples on docker-run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Clone the repo to get get started and follow these steps:
 
 3. Use the k6 Docker image to run the k6 script and send metrics to the InfluxDB container started on the previous step. You must [set the `testid` tag](https://k6.io/docs/using-k6/tags-and-groups/#test-wide-tags) with a unique identifier to segment the metrics into discrete test runs for the Grafana dashboards.
     ```shell
-    docker-compose run --rm k6 run -<scripts/http_2.js --tag testid=<SOME-ID>
+    docker-compose run --rm k6 run -<samples/http_2.js --tag testid=<SOME-ID>
     ```
    For convenience, the `docker-run.sh` can be used to simply:
     ```shell
-    ./docker-run.sh scripts/http_2.js
+    ./docker-run.sh samples/http_2.js
     ```
 
 4. Visit http://localhost:3000/ to view results in Grafana. 


### PR DESCRIPTION
I was following the docs and find a wrong folder name on it.