### PR TITLE
Bump Go and Alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20-alpine3.17 as builder
+FROM golang:1.22-alpine3.20 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 ADD . .
 RUN apk --no-cache add git
 RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --with github.com/grafana/xk6-output-influxdb=. --output /tmp/k6
 
-FROM alpine:3.17
+FROM alpine:3.20
 RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /tmp/k6 /usr/bin/k6


### PR DESCRIPTION
It bumps the versions and closes #33 