### PR TITLE
Bump dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22-alpine3.20 as builder
+FROM golang:1.23-alpine3.21 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 ADD . .
 RUN apk --no-cache add git
 RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --with github.com/grafana/xk6-output-influxdb=. --output /tmp/k6
 
-FROM alpine:3.20
+FROM alpine:3.21
 RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /tmp/k6 /usr/bin/k6


### PR DESCRIPTION
It should fix the certificate issue https://community.grafana.com/t/getting-certificate-issue-on-running-the-xk6-via-docker-compose-with-influxdb-and-grafana/141625

It also keeps the project up to date.