### PR TITLE
feat(influxdb): add optional JMeter-style aggregated output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,30 @@ Your tags — both k6 built-in tags and your own custom tags (set via test-wide 
 | K6_INFLUXDB_AGGREGATION_ENABLED        | false | When `true`, send aggregated summaries instead of raw per-sample points. |
 | K6_INFLUXDB_AGGREGATION_FLUSH_INTERVAL | 5s    | How often aggregated summaries are written. |
 | K6_INFLUXDB_AGGREGATION_MEASUREMENT    | k6_aggregated | InfluxDB measurement name for aggregated points. |
-| K6_INFLUXDB_AGGREGATION_PERCENTILES    | 90,95,99 | Response-time percentiles to compute (rendered as fields `p90`, `p95`, ...). |
+| K6_INFLUXDB_AGGREGATION_PERCENTILES    | 90,95,99 | Response-time percentiles to compute (rendered as fields `p90`/`pct90.0`, depending on schema — see below). |
 | K6_INFLUXDB_AGGREGATION_DROP_TAGS      | vu,iter,url | Comma-separated denylist of high-cardinality tags excluded from the aggregation grouping. Every other tag (built-in or custom) is kept automatically. |
+| K6_INFLUXDB_AGGREGATION_SCHEMA         | k6 | Tag/field naming scheme for aggregated points: `k6` (this output's own naming) or `jmeter`, which mirrors a real JMeter InfluxDB backend listener's schema so existing JMeter dashboards/queries can be reused against k6 data. |
 
-**Schema of aggregated points** (measurement `k6_aggregated`):
+### `k6` schema (default)
 
-- Tags: `name` (request name), `group`, `result` (`ok`/`ko`/`all`/`status`), plus every other tag on the sample (your custom tags such as `testid`, plus built-in tags like `method`, `scenario`) except those in the denylist.
+- Tags: `name` (request name), `group`, `statut` (`ok`/`ko`/`all`), plus every other tag on the sample (your custom tags such as `testid`, plus built-in tags like `method`, `scenario`) except those in the denylist.
 - Fields (per request/group row): `count`, `avg`, `min`, `max`, `hits`, and one field per configured percentile (`p90`, `p95`, `p99`, ...).
-- A per-error row (tags `result=ko`, `status` = HTTP code, `error` = message) with `errors` count.
-- Per-HTTP-status-code rows (tags `result=status`, `status` = HTTP code such as `200`/`404`/`0`) with a `count` field. These give a full response-code distribution — **including successful 2xx** — even though the main ok/ko/all rows omit the status code. Counts are additive across flush windows, so a response-code chart is exact at any time range. (`status=0` denotes a transport-level failure: connection refused, timeout, DNS, etc.)
-- A cumulative row (`name=all`, `result=all`) with exact run-wide `count`, `avg`, `min`, `max`, percentiles (`p90`/`p95`/...), `hits`, `errors`, plus `data_sent` and `data_received`. (`data_sent`/`data_received` are run-wide totals because k6 measures them at the connection level and cannot attribute them to individual requests.)
-- An `name=internal` row with active-VU metrics `vus_min`, `vus_max`, `vus_mean`.
+- Per-response-code rows (tags `status` = HTTP code such as `200`/`404`/`0`, `error` = message when not a success) with a `count` field. These give a full response-code distribution — **including successful 2xx** — even though the main ok/ko/all rows omit the status code. Counts are additive across flush windows, so a response-code chart is exact at any time range. (`status=0` denotes a transport-level failure: connection refused, timeout, DNS, etc.)
+- A cumulative row (`name=all`, `statut=all`) with exact run-wide `count`, `avg`, `min`, `max`, percentiles, `hits`, `countError`, plus `data_sent` and `data_received`. (`data_sent`/`data_received` are run-wide totals because k6 measures them at the connection level and cannot attribute them to individual requests.)
+- A `name=internal` row with active-VU metrics `minAT`, `maxAT`, `meanAT`.
 
-The response-time signal is k6's `http_req_duration`; `ok`/`ko` is derived from the sample's `expected_response` tag. Note the synthetic ok/ko/all split is exposed as the `result` tag, kept separate from k6's built-in `status` (HTTP status code) tag.
+### `jmeter` schema (opt-in, `K6_INFLUXDB_AGGREGATION_SCHEMA=jmeter`)
+
+Structurally identical to a real JMeter InfluxDB backend listener's output (verified against a live JMeter-written bucket), so existing JMeter dashboards/queries work unmodified against k6 data — only the values differ, not the shape:
+
+- Tags: `transaction` (k6's `group` + `name` combined, e.g. `checkout::GET /cart`), `statut` (`ok`/`ko`/`all`). k6-only tags with no JMeter equivalent (`method`, `proto`, `tls_version`, `scenario`) are dropped; any other custom tag (e.g. `application`, `testTitle` set via k6's `options.tags`) still passes through.
+- Fields (per request/group row): `count`, `avg`, `min`, `max`, `hit`, and one field per configured percentile (`pct90.0`, `pct95.0`, `pct99.0`, ...).
+- Per-response-code rows (tags `responseCode`, `responseMessage` — `"OK"` on success) with a `count` field, no `statut` tag. Same additive-counts behavior as the k6 schema.
+- A cumulative row (`transaction=all`, `statut=all`) with exact run-wide `count`, `avg`, `min`, `max`, percentiles, `hit`, `countError`. No `data_sent`/`data_received` (no JMeter equivalent).
+- A `transaction=internal` row with active-VU metrics `minAT`, `maxAT`, `meanAT`.
+- Real JMeter's `rb`/`sb` (per-request byte counts) and `startedT`/`endedT` (threads started/ended per interval) are **not** emitted — k6 has no equivalent per-request data.
+
+In both schemas the response-time signal is k6's `http_req_duration`; `ok`/`ko` is derived from the sample's `expected_response` tag. The synthetic ok/ko/all split is exposed as the `statut` tag, kept separate from k6's built-in `status` (HTTP status code) tag.
 
 
 # Docker Compose

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ Options for fine-grained control for flushing and connections.
 | K6_INFLUXDB_PRECISION         | 1ns | The timestamp [Precision](https://docs.influxdata.com/influxdb/v2.0/reference/glossary/#precision). |
 
 
+## Aggregated metrics (JMeter-style)
+
+By default this output writes **one InfluxDB point per metric sample**, which can overwhelm InfluxDB under high load. You can instead enable optional **aggregation**, which buffers samples over a time window and writes compact JMeter-style summaries (count / avg / min / max / percentiles per request and group, split into `ok`/`ko`/`all`), drastically reducing the number of points written.
+
+Aggregation is **off by default**; when off, behavior is unchanged. Enable it with `K6_INFLUXDB_AGGREGATION_ENABLED=true`.
+
+Your tags — both k6 built-in tags and your own custom tags (set via test-wide `tags` in options or per-request) — are carried into the aggregated output **automatically**, with no extra configuration. Only a small denylist of known high-cardinality tags (`vu`, `iter`, `url`) is excluded so the series count stays manageable.
+
+| ENV | Default | Description |
+|-----|---------|-------------|
+| K6_INFLUXDB_AGGREGATION_ENABLED        | false | When `true`, send aggregated summaries instead of raw per-sample points. |
+| K6_INFLUXDB_AGGREGATION_FLUSH_INTERVAL | 5s    | How often aggregated summaries are written. |
+| K6_INFLUXDB_AGGREGATION_MEASUREMENT    | k6_aggregated | InfluxDB measurement name for aggregated points. |
+| K6_INFLUXDB_AGGREGATION_PERCENTILES    | 90,95,99 | Response-time percentiles to compute (rendered as fields `p90`, `p95`, ...). |
+| K6_INFLUXDB_AGGREGATION_DROP_TAGS      | vu,iter,url | Comma-separated denylist of high-cardinality tags excluded from the aggregation grouping. Every other tag (built-in or custom) is kept automatically. |
+
+**Schema of aggregated points** (measurement `k6_aggregated`):
+
+- Tags: `name` (request name), `group`, `result` (`ok`/`ko`/`all`/`status`), plus every other tag on the sample (your custom tags such as `testid`, plus built-in tags like `method`, `scenario`) except those in the denylist.
+- Fields (per request/group row): `count`, `avg`, `min`, `max`, `hits`, and one field per configured percentile (`p90`, `p95`, `p99`, ...).
+- A per-error row (tags `result=ko`, `status` = HTTP code, `error` = message) with `errors` count.
+- Per-HTTP-status-code rows (tags `result=status`, `status` = HTTP code such as `200`/`404`/`0`) with a `count` field. These give a full response-code distribution — **including successful 2xx** — even though the main ok/ko/all rows omit the status code. Counts are additive across flush windows, so a response-code chart is exact at any time range. (`status=0` denotes a transport-level failure: connection refused, timeout, DNS, etc.)
+- A cumulative row (`name=all`, `result=all`) with exact run-wide `count`, `avg`, `min`, `max`, percentiles (`p90`/`p95`/...), `hits`, `errors`, plus `data_sent` and `data_received`. (`data_sent`/`data_received` are run-wide totals because k6 measures them at the connection level and cannot attribute them to individual requests.)
+- An `name=internal` row with active-VU metrics `vus_min`, `vus_max`, `vus_mean`.
+
+The response-time signal is k6's `http_req_duration`; `ok`/`ko` is derived from the sample's `expected_response` tag. Note the synthetic ok/ko/all split is exposed as the `result` tag, kept separate from k6's built-in `status` (HTTP status code) tag.
+
+
 # Docker Compose
 
 This repo includes a [docker-compose.yml](./docker-compose.yml) file that starts InfluxDB, Grafana and k6. This is just a quick setup to show the usage; for real use case you might want to deploy outside of docker, use volumes and probably update versions.

--- a/grafana/dashboards/xk6-output-influxdb-aggregated-dashboard.json
+++ b/grafana/dashboards/xk6-output-influxdb-aggregated-dashboard.json
@@ -1,0 +1,544 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "iteration": 1677877089957,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"count\")\n  |> group()\n  |> sum()\n  |> yield(name: \"sum\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Made",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"errors\")\n  |> group()\n  |> sum()\n  |> yield(name: \"sum\")",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"count\")\n  |> group()\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({ r with _value: r._value / (float(v: int(v: v.windowPeriod)) / 1000000000.0) }))",
+          "refId": "A"
+        }
+      ],
+      "title": "Peak RPS",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"p95\")\n  |> group()\n  |> mean()",
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Response Time",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"data_received\")\n  |> group()\n  |> sum()",
+          "refId": "A"
+        }
+      ],
+      "title": "Data Received",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"data_sent\")\n  |> group()\n  |> sum()",
+          "refId": "A"
+        }
+      ],
+      "title": "Data Sent",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "displayName": "Avg Response - ${__field.labels.testid}",
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Active VUs"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RPS"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "hide": false,
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"avg\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        },
+        {
+          "hide": false,
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"internal\")\n  |> filter(fn: (r) => r[\"_field\"] == \"vus_max\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)",
+          "refId": "B"
+        },
+        {
+          "hide": false,
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_aggregated\")\n  |> filter(fn: (r) => r[\"testid\"] =~ /${testid:regex}/)\n  |> filter(fn: (r) => r[\"name\"] == \"all\")\n  |> filter(fn: (r) => r[\"result\"] == \"all\")\n  |> filter(fn: (r) => r[\"_field\"] == \"count\")\n  |> group()\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({ r with _value: r._value / (float(v: int(v: v.windowPeriod)) / 1000000000.0) }))",
+          "refId": "C"
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 32,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": null,
+        "definition": "import \"influxdata/influxdb/schema\"\nschema.tagValues(bucket: v.defaultBucket, tag: \"testid\")",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "testid",
+        "options": [],
+        "query": "import \"influxdata/influxdb/schema\"\nschema.tagValues(bucket: v.defaultBucket, tag: \"testid\")",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "K6 Aggregated Test Results",
+  "uid": "4sk8QaJVxAGG",
+  "version": 1
+}

--- a/pkg/influxdb/aggregator.go
+++ b/pkg/influxdb/aggregator.go
@@ -15,31 +15,42 @@ const (
 	statusKO  = "ko"
 	statusAll = "all"
 
-	// resultStatusCount marks the per-HTTP-status-code counter rows. These sit
-	// alongside the ok/ko/all rows and carry only a `count` field (no percentiles),
-	// so a full response-code distribution — including successful 2xx — can be
-	// charted in aggregated mode. Counts are additive across flush windows.
-	resultStatusCount = "status"
+	// okMessage is the synthetic responseMessage used for successful samples,
+	// mirroring JMeter's own "OK" message on its per-response-code breakdown rows.
+	okMessage = "OK"
 )
 
-// k6 metric names and tag keys used by the aggregator. Response time is modeled
-// on http_req_duration, exactly like JMeter models it on the sampler elapsed time.
+// Aggregation schema modes, selected by Config.Aggregation.Schema.
+const (
+	schemaK6     = "k6"
+	schemaJMeter = "jmeter"
+)
+
+// k6 metric names ingested by the aggregator. Response time is modeled on
+// http_req_duration, exactly like JMeter models it on the sampler elapsed time.
 const (
 	metricHTTPReqDuration = "http_req_duration"
 	metricDataSent        = "data_sent"
 	metricDataReceived    = "data_received"
 	metricVUs             = "vus"
+)
 
+// k6 sample tag keys read by the aggregator. These describe the *input* (raw k6
+// sample tags) and never change with the output schema; what varies by schema is
+// how they get renamed/combined/dropped on the way out -- see schemaDef below.
+const (
 	tagName             = "name"
+	tagGroup            = "group"
 	tagStatus           = "status"
 	tagError            = "error"
 	tagErrorCode        = "error_code"
 	tagExpectedResponse = "expected_response"
-
-	// tagResult holds the synthetic ok/ko/all split. It is deliberately distinct
-	// from k6's built-in "status" (HTTP status code) tag to avoid a collision.
-	tagResult = "result"
 )
+
+// tagResult is the tag key both schemas use for the synthetic ok/ko/all split,
+// under JMeter's own name ("statut"). Deliberately distinct from k6's built-in
+// "status" (HTTP status code) tag to avoid a collision.
+const tagResult = "statut"
 
 // internalTags are read by the aggregator itself (for the ok/ko split and the
 // per-error breakdown) and are never used as grouping dimensions.
@@ -48,6 +59,94 @@ var internalTags = map[string]bool{
 	tagStatus:           true,
 	tagError:            true,
 	tagErrorCode:        true,
+}
+
+// schemaDef fully describes one aggregation output schema's tag/field naming.
+// aggregateBatch and baseTags never branch on which schema is active -- they
+// look values up on the active schemaDef instead. Every schema-dependent
+// decision lives here, in exactly one of the two schemaDef values below.
+type schemaDef struct {
+	// hitField is the field name for the per-window hit/request count.
+	hitField string
+	// countErrorField is the field name for the cumulative error count, set only
+	// on the "all" rollup row.
+	countErrorField string
+	// percentileField renders a percentile (e.g. 90) as its field name.
+	percentileField func(p float64) string
+	// combineTransaction merges tagName+tagGroup into a single transactionTag
+	// when true (JMeter has no separate group concept); when false, tagName and
+	// tagGroup stay separate tags and transactionTag is unused.
+	combineTransaction bool
+	transactionTag     string
+	// responseCodeTag/responseMessageTag are the tag keys used on the
+	// per-response-code breakdown rows.
+	responseCodeTag    string
+	responseMessageTag string
+	// omitSuccessMessage suppresses responseMessageTag on successful rows. Set
+	// for k6 schema so it doesn't invent a new "error" tag value that never
+	// existed on 2xx/3xx rows before this feature added response-code breakdown
+	// rows; JMeter's own schema always sets it (including "OK" on success).
+	omitSuccessMessage bool
+	// includeConnectionTotals reports data_sent/data_received on the cumulative
+	// row. k6 measures these at the connection level, with no per-transaction or
+	// JMeter equivalent.
+	includeConnectionTotals bool
+	// droppedTags are tag keys with no equivalent in this schema, excluded at
+	// both grouping time (see newAggregator) and emission time (see baseTags).
+	droppedTags map[string]bool
+	// minActiveField/maxActiveField/meanActiveField are the active-thread (VU)
+	// field names on the separate "internal" row.
+	minActiveField  string
+	maxActiveField  string
+	meanActiveField string
+}
+
+// k6Schema is this output's own naming (Aggregation.Schema == "k6", the
+// default): unchanged from before this feature added a second schema.
+var k6Schema = schemaDef{
+	hitField:                "hits",
+	countErrorField:         "countError",
+	percentileField:         percentileField,
+	combineTransaction:      false,
+	responseCodeTag:         tagStatus,
+	responseMessageTag:      tagError,
+	omitSuccessMessage:      true,
+	includeConnectionTotals: true,
+	minActiveField:          "minAT",
+	maxActiveField:          "maxAT",
+	meanActiveField:         "meanAT",
+}
+
+// jmeterSchema mirrors a real JMeter InfluxDB backend listener's own schema
+// (verified against a live JMeter-written bucket via the InfluxDB MCP during
+// design), so existing JMeter dashboards/queries can be reused against k6 data.
+var jmeterSchema = schemaDef{
+	hitField:                "hit",
+	countErrorField:         "countError",
+	percentileField:         jmeterPercentileField,
+	combineTransaction:      true,
+	transactionTag:          "transaction",
+	responseCodeTag:         "responseCode",
+	responseMessageTag:      "responseMessage",
+	includeConnectionTotals: false,
+	droppedTags: map[string]bool{
+		"method":      true,
+		"proto":       true,
+		"tls_version": true,
+		"scenario":    true,
+	},
+	minActiveField:  "minAT",
+	maxActiveField:  "maxAT",
+	meanActiveField: "meanAT",
+}
+
+// schemaFor returns the schemaDef for a Config.Aggregation.Schema value,
+// defaulting to k6Schema for "" (unset) or "k6".
+func schemaFor(name string) schemaDef {
+	if name == schemaJMeter {
+		return jmeterSchema
+	}
+	return k6Schema
 }
 
 // k6LifecycleGroups are the raw group tag values k6 assigns to requests made
@@ -62,8 +161,8 @@ var k6LifecycleGroups = map[string]bool{
 // keys (it cannot appear in normal tag values).
 const groupSeparator = "\x1f"
 
-// errKey identifies a unique error bucket, like JMeter's ErrorMetric
-// (response code + message).
+// errKey identifies a unique (response code, message) bucket, like JMeter's own
+// per-response-code breakdown rows.
 type errKey struct {
 	status string
 	msg    string
@@ -84,25 +183,23 @@ type samplerMetric struct {
 	failures  int64
 	hits      int64
 
-	errors map[errKey]int64
-
-	// statusCounts holds the per-HTTP-status-code request count (e.g. "200" -> 9,
-	// "500" -> 1). Unlike the ok/ko split, this keeps every distinct code so a
-	// full response-code distribution can be reported.
-	statusCounts map[string]int64
+	// statusCounts holds the per-(status, message) request count (e.g. ("200","OK")
+	// -> 9, ("500","boom") -> 1), covering every distinct response, not just
+	// failures, so a full response-code distribution can be reported -- mirroring
+	// JMeter's own per-response-code rows, which carry no ok/ko/all split.
+	statusCounts map[errKey]int64
 }
 
 func newSamplerMetric(tags map[string]string) *samplerMetric {
 	return &samplerMetric{
 		tags:         tags,
-		errors:       make(map[errKey]int64),
-		statusCounts: make(map[string]int64),
+		statusCounts: make(map[errKey]int64),
 	}
 }
 
 // addDuration records a single response-time observation, routing it into the
-// ok/ko/all buckets just like JMeter does, and counting its HTTP status code.
-func (m *samplerMetric) addDuration(v float64, ok bool, status string, ek errKey) {
+// ok/ko/all buckets just like JMeter does, and counting its (status, message) pair.
+func (m *samplerMetric) addDuration(v float64, ok bool, status, errMsg string) {
 	m.allValues = append(m.allValues, v)
 	m.hits++
 	// k6 reports status "0" for transport-level failures (connection refused,
@@ -110,14 +207,20 @@ func (m *samplerMetric) addDuration(v float64, ok bool, status string, ek errKey
 	if status == "" {
 		status = "0"
 	}
-	m.statusCounts[status]++
+	msg := errMsg
+	switch {
+	case ok:
+		msg = okMessage
+	case msg == "":
+		msg = "KO"
+	}
+	m.statusCounts[errKey{status: status, msg: msg}]++
 	if ok {
 		m.okValues = append(m.okValues, v)
 		m.successes++
 	} else {
 		m.koValues = append(m.koValues, v)
 		m.failures++
-		m.errors[ek]++
 	}
 }
 
@@ -150,6 +253,7 @@ type aggregator struct {
 	dropTags    map[string]bool
 	percentiles []float64
 	measurement string
+	schema      string
 
 	groups map[string]*samplerMetric
 	users  userMetric
@@ -166,10 +270,23 @@ func newAggregator(c Config) *aggregator {
 	for _, t := range c.Aggregation.DropTags {
 		drop[t] = true
 	}
+	schema := c.Aggregation.Schema.String
+	if schema == "" {
+		schema = schemaK6
+	}
+	// Drop the active schema's droppedTags at grouping time too, not just at
+	// emission time in baseTags: otherwise two groups differing only by one of
+	// these tags would still be grouped separately but emit points with an
+	// identical schema tag set and timestamp, silently overwriting each other in
+	// InfluxDB instead of being counted together.
+	for t := range schemaFor(schema).droppedTags {
+		drop[t] = true
+	}
 	return &aggregator{
 		dropTags:    drop,
 		percentiles: c.Aggregation.Percentiles,
 		measurement: c.Aggregation.Measurement.String,
+		schema:      schema,
 		groups:      make(map[string]*samplerMetric),
 	}
 }
@@ -185,7 +302,7 @@ func (a *aggregator) groupTags(tagMap map[string]string) map[string]string {
 		}
 		// k6 stores group paths as "::root::child"; strip the leading "::" so
 		// the tag value is human-readable (e.g. "DCPAN-TR-01-homepage").
-		if k == "group" {
+		if k == tagGroup {
 			v = strings.TrimPrefix(v, "::")
 		}
 		tags[k] = v
@@ -236,16 +353,12 @@ func (a *aggregator) ingest(containers []metrics.SampleContainer) {
 			switch s.Metric.Name {
 			case metricHTTPReqDuration:
 				tagMap := s.Tags.Map()
-				if k6LifecycleGroups[tagMap["group"]] {
+				if k6LifecycleGroups[tagMap[tagGroup]] {
 					continue
 				}
 				m := a.metricFor(tagMap)
 				ok := tagMap[tagExpectedResponse] != "false"
-				var ek errKey
-				if !ok {
-					ek = errKey{status: tagMap[tagStatus], msg: tagMap[tagError]}
-				}
-				m.addDuration(s.Value, ok, tagMap[tagStatus], ek)
+				m.addDuration(s.Value, ok, tagMap[tagStatus], tagMap[tagError])
 			case metricDataSent:
 				a.totalSent += s.Value
 			case metricDataReceived:
@@ -266,6 +379,7 @@ type aggSnapshot struct {
 	totalReceived float64
 	percentiles   []float64
 	measurement   string
+	schema        string
 }
 
 // drain atomically swaps out the current window for a fresh empty one and returns
@@ -282,6 +396,7 @@ func (a *aggregator) drain() aggSnapshot {
 		totalReceived: a.totalReceived,
 		percentiles:   a.percentiles,
 		measurement:   a.measurement,
+		schema:        a.schema,
 	}
 	a.groups = make(map[string]*samplerMetric)
 	a.users = userMetric{}
@@ -291,8 +406,9 @@ func (a *aggregator) drain() aggSnapshot {
 }
 
 // statsFields computes the JMeter-style summary fields (count/min/max/avg + the
-// configured percentiles) for a slice of response-time values.
-func statsFields(values []float64, percentiles []float64) map[string]any {
+// configured percentiles) for a slice of response-time values. percentileFieldFn
+// renders each percentile's field name, and differs by aggregation schema.
+func statsFields(values []float64, percentiles []float64, percentileFieldFn func(float64) string) map[string]any {
 	count := int64(len(values))
 	fields := map[string]any{"count": count}
 	if count == 0 {
@@ -317,7 +433,7 @@ func statsFields(values []float64, percentiles []float64) map[string]any {
 	copy(sorted, values)
 	sort.Float64s(sorted)
 	for _, p := range percentiles {
-		fields[percentileField(p)] = quantile(sorted, p)
+		fields[percentileFieldFn(p)] = quantile(sorted, p)
 	}
 	return fields
 }
@@ -342,12 +458,22 @@ func quantile(sorted []float64, p float64) float64 {
 	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
 }
 
-// percentileField renders a percentile as an InfluxDB field name, e.g. 90 -> "p90",
-// 99.9 -> "p99_9".
+// percentileField renders a percentile as a k6-schema InfluxDB field name, e.g.
+// 90 -> "p90", 99.9 -> "p99_9".
 func percentileField(p float64) string {
 	s := strconv.FormatFloat(p, 'f', -1, 64)
 	s = strings.ReplaceAll(s, ".", "_")
 	return "p" + s
+}
+
+// jmeterPercentileField renders a percentile as JMeter's own field name, e.g.
+// 90 -> "pct90.0", 99.9 -> "pct99.9". JMeter always includes a decimal point.
+func jmeterPercentileField(p float64) string {
+	s := strconv.FormatFloat(p, 'f', -1, 64)
+	if !strings.Contains(s, ".") {
+		s += ".0"
+	}
+	return "pct" + s
 }
 
 // copyTags returns a shallow copy of a tag map so callers can add per-point tags

--- a/pkg/influxdb/aggregator.go
+++ b/pkg/influxdb/aggregator.go
@@ -1,0 +1,361 @@
+package influxdb
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"go.k6.io/k6/v2/metrics"
+)
+
+// Aggregation status values, mirroring JMeter's ok/ko/all transaction split.
+const (
+	statusOK  = "ok"
+	statusKO  = "ko"
+	statusAll = "all"
+
+	// resultStatusCount marks the per-HTTP-status-code counter rows. These sit
+	// alongside the ok/ko/all rows and carry only a `count` field (no percentiles),
+	// so a full response-code distribution — including successful 2xx — can be
+	// charted in aggregated mode. Counts are additive across flush windows.
+	resultStatusCount = "status"
+)
+
+// k6 metric names and tag keys used by the aggregator. Response time is modeled
+// on http_req_duration, exactly like JMeter models it on the sampler elapsed time.
+const (
+	metricHTTPReqDuration = "http_req_duration"
+	metricDataSent        = "data_sent"
+	metricDataReceived    = "data_received"
+	metricVUs             = "vus"
+
+	tagName             = "name"
+	tagStatus           = "status"
+	tagError            = "error"
+	tagErrorCode        = "error_code"
+	tagExpectedResponse = "expected_response"
+
+	// tagResult holds the synthetic ok/ko/all split. It is deliberately distinct
+	// from k6's built-in "status" (HTTP status code) tag to avoid a collision.
+	tagResult = "result"
+)
+
+// internalTags are read by the aggregator itself (for the ok/ko split and the
+// per-error breakdown) and are never used as grouping dimensions.
+var internalTags = map[string]bool{
+	tagExpectedResponse: true,
+	tagStatus:           true,
+	tagError:            true,
+	tagErrorCode:        true,
+}
+
+// k6LifecycleGroups are the raw group tag values k6 assigns to requests made
+// during its own setup/teardown lifecycle phases (not user-defined groups).
+// Samples from these phases are skipped so they don't pollute the transaction list.
+var k6LifecycleGroups = map[string]bool{
+	"::setup":    true,
+	"::teardown": true,
+}
+
+// groupSeparator is an ASCII unit separator used to build collision-safe group
+// keys (it cannot appear in normal tag values).
+const groupSeparator = "\x1f"
+
+// errKey identifies a unique error bucket, like JMeter's ErrorMetric
+// (response code + message).
+type errKey struct {
+	status string
+	msg    string
+}
+
+// samplerMetric accumulates response-time samples for one (name, group, extraTags)
+// group over a single flush window. Mirrors JMeter's SamplerMetric.
+type samplerMetric struct {
+	// tags is the snapshot of grouping tag values (name, group, extra tags) used
+	// when emitting points.
+	tags map[string]string
+
+	okValues  []float64
+	koValues  []float64
+	allValues []float64
+
+	successes int64
+	failures  int64
+	hits      int64
+
+	errors map[errKey]int64
+
+	// statusCounts holds the per-HTTP-status-code request count (e.g. "200" -> 9,
+	// "500" -> 1). Unlike the ok/ko split, this keeps every distinct code so a
+	// full response-code distribution can be reported.
+	statusCounts map[string]int64
+}
+
+func newSamplerMetric(tags map[string]string) *samplerMetric {
+	return &samplerMetric{
+		tags:         tags,
+		errors:       make(map[errKey]int64),
+		statusCounts: make(map[string]int64),
+	}
+}
+
+// addDuration records a single response-time observation, routing it into the
+// ok/ko/all buckets just like JMeter does, and counting its HTTP status code.
+func (m *samplerMetric) addDuration(v float64, ok bool, status string, ek errKey) {
+	m.allValues = append(m.allValues, v)
+	m.hits++
+	// k6 reports status "0" for transport-level failures (connection refused,
+	// timeout, DNS); fall back to "0" if the tag is somehow absent.
+	if status == "" {
+		status = "0"
+	}
+	m.statusCounts[status]++
+	if ok {
+		m.okValues = append(m.okValues, v)
+		m.successes++
+	} else {
+		m.koValues = append(m.koValues, v)
+		m.failures++
+		m.errors[ek]++
+	}
+}
+
+// userMetric tracks active-VU (thread) counts over a flush window. Mirrors the
+// thread metrics from JMeter's UserMetric (min/max/mean active threads).
+type userMetric struct {
+	min   float64
+	max   float64
+	sum   float64
+	count int64
+}
+
+func (u *userMetric) add(v float64) {
+	if u.count == 0 || v < u.min {
+		u.min = v
+	}
+	if u.count == 0 || v > u.max {
+		u.max = v
+	}
+	u.sum += v
+	u.count++
+}
+
+// aggregator holds the cross-interval aggregation state. It survives the raw
+// sample-buffer drains (which happen every PushInterval) and is itself drained
+// and reset every aggregation FlushInterval.
+type aggregator struct {
+	mu sync.Mutex
+
+	dropTags    map[string]bool
+	percentiles []float64
+	measurement string
+
+	groups map[string]*samplerMetric
+	users  userMetric
+
+	// data_sent/data_received are measured by k6 at the connection level and
+	// cannot be attributed to individual requests, so they are tracked as global
+	// totals and reported on the cumulative row.
+	totalSent     float64
+	totalReceived float64
+}
+
+func newAggregator(c Config) *aggregator {
+	drop := make(map[string]bool, len(c.Aggregation.DropTags))
+	for _, t := range c.Aggregation.DropTags {
+		drop[t] = true
+	}
+	return &aggregator{
+		dropTags:    drop,
+		percentiles: c.Aggregation.Percentiles,
+		measurement: c.Aggregation.Measurement.String,
+		groups:      make(map[string]*samplerMetric),
+	}
+}
+
+// groupTags keeps every tag on the sample (built-in or custom) except the
+// high-cardinality denylist and the internally-consumed tags. This way custom
+// tags flow into the aggregated output automatically, with no extra config.
+func (a *aggregator) groupTags(tagMap map[string]string) map[string]string {
+	tags := make(map[string]string, len(tagMap))
+	for k, v := range tagMap {
+		if v == "" || internalTags[k] || a.dropTags[k] {
+			continue
+		}
+		// k6 stores group paths as "::root::child"; strip the leading "::" so
+		// the tag value is human-readable (e.g. "DCPAN-TR-01-homepage").
+		if k == "group" {
+			v = strings.TrimPrefix(v, "::")
+		}
+		tags[k] = v
+	}
+	return tags
+}
+
+// groupKey builds a stable, collision-safe key from a sorted snapshot of the
+// grouping tags.
+func groupKey(tags map[string]string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(tags[k])
+		b.WriteString(groupSeparator)
+	}
+	return b.String()
+}
+
+// metricFor returns (creating if needed) the samplerMetric for a sample's group.
+// Callers must hold a.mu.
+func (a *aggregator) metricFor(tagMap map[string]string) *samplerMetric {
+	tags := a.groupTags(tagMap)
+	key := groupKey(tags)
+	m := a.groups[key]
+	if m == nil {
+		m = newSamplerMetric(tags)
+		a.groups[key] = m
+	}
+	return m
+}
+
+// ingest folds a batch of samples into the rolling aggregation state. Only the
+// metrics JMeter models are considered; everything else is ignored.
+func (a *aggregator) ingest(containers []metrics.SampleContainer) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for _, container := range containers {
+		for _, s := range container.GetSamples() {
+			switch s.Metric.Name {
+			case metricHTTPReqDuration:
+				tagMap := s.Tags.Map()
+				if k6LifecycleGroups[tagMap["group"]] {
+					continue
+				}
+				m := a.metricFor(tagMap)
+				ok := tagMap[tagExpectedResponse] != "false"
+				var ek errKey
+				if !ok {
+					ek = errKey{status: tagMap[tagStatus], msg: tagMap[tagError]}
+				}
+				m.addDuration(s.Value, ok, tagMap[tagStatus], ek)
+			case metricDataSent:
+				a.totalSent += s.Value
+			case metricDataReceived:
+				a.totalReceived += s.Value
+			case metricVUs:
+				a.users.add(s.Value)
+			}
+		}
+	}
+}
+
+// aggSnapshot is a drained window of aggregation state, ready to be turned into
+// points outside of the aggregator lock.
+type aggSnapshot struct {
+	groups        map[string]*samplerMetric
+	users         userMetric
+	totalSent     float64
+	totalReceived float64
+	percentiles   []float64
+	measurement   string
+}
+
+// drain atomically swaps out the current window for a fresh empty one and returns
+// the old state. This is the per-interval reset, equivalent to JMeter's
+// resetForTimeInterval.
+func (a *aggregator) drain() aggSnapshot {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	snap := aggSnapshot{
+		groups:        a.groups,
+		users:         a.users,
+		totalSent:     a.totalSent,
+		totalReceived: a.totalReceived,
+		percentiles:   a.percentiles,
+		measurement:   a.measurement,
+	}
+	a.groups = make(map[string]*samplerMetric)
+	a.users = userMetric{}
+	a.totalSent = 0
+	a.totalReceived = 0
+	return snap
+}
+
+// statsFields computes the JMeter-style summary fields (count/min/max/avg + the
+// configured percentiles) for a slice of response-time values.
+func statsFields(values []float64, percentiles []float64) map[string]any {
+	count := int64(len(values))
+	fields := map[string]any{"count": count}
+	if count == 0 {
+		return fields
+	}
+
+	min, max, sum := values[0], values[0], 0.0
+	for _, v := range values {
+		sum += v
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	fields["min"] = min
+	fields["max"] = max
+	fields["avg"] = sum / float64(count)
+
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+	for _, p := range percentiles {
+		fields[percentileField(p)] = quantile(sorted, p)
+	}
+	return fields
+}
+
+// quantile returns the p-th percentile (0..100) of a sorted slice using linear
+// interpolation, matching Apache Commons Math DescriptiveStatistics.getPercentile
+// as used by JMeter.
+func quantile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	rank := (p / 100) * float64(n-1)
+	lo := int(rank)
+	if lo >= n-1 {
+		return sorted[n-1]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
+}
+
+// percentileField renders a percentile as an InfluxDB field name, e.g. 90 -> "p90",
+// 99.9 -> "p99_9".
+func percentileField(p float64) string {
+	s := strconv.FormatFloat(p, 'f', -1, 64)
+	s = strings.ReplaceAll(s, ".", "_")
+	return "p" + s
+}
+
+// copyTags returns a shallow copy of a tag map so callers can add per-point tags
+// (like status) without mutating the shared group snapshot.
+func copyTags(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src)+1)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/pkg/influxdb/aggregator_test.go
+++ b/pkg/influxdb/aggregator_test.go
@@ -1,0 +1,151 @@
+package influxdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/metrics"
+)
+
+func TestQuantile(t *testing.T) {
+	t.Parallel()
+
+	sorted := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	assert.InDelta(t, 1.0, quantile(sorted, 0), 1e-9)
+	assert.InDelta(t, 10.0, quantile(sorted, 100), 1e-9)
+	assert.InDelta(t, 5.5, quantile(sorted, 50), 1e-9)
+	// p90 on a 10-element slice with linear interpolation: rank = 0.9*9 = 8.1 -> 9.1
+	assert.InDelta(t, 9.1, quantile(sorted, 90), 1e-9)
+
+	assert.Equal(t, 0.0, quantile(nil, 95))
+	assert.Equal(t, 42.0, quantile([]float64{42}, 95))
+}
+
+func TestPercentileField(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "p90", percentileField(90))
+	assert.Equal(t, "p95", percentileField(95))
+	assert.Equal(t, "p99_9", percentileField(99.9))
+}
+
+func TestStatsFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		f := statsFields(nil, []float64{95})
+		assert.Equal(t, int64(0), f["count"])
+		_, hasAvg := f["avg"]
+		assert.False(t, hasAvg)
+	})
+
+	t.Run("values", func(t *testing.T) {
+		t.Parallel()
+		f := statsFields([]float64{10, 20, 30, 40}, []float64{90, 99})
+		assert.Equal(t, int64(4), f["count"])
+		assert.InDelta(t, 10.0, f["min"], 1e-9)
+		assert.InDelta(t, 40.0, f["max"], 1e-9)
+		assert.InDelta(t, 25.0, f["avg"], 1e-9)
+		assert.Contains(t, f, "p90")
+		assert.Contains(t, f, "p99")
+	})
+}
+
+func TestGroupTagsAndKey(t *testing.T) {
+	t.Parallel()
+
+	a := newAggregator(NewConfig()) // default dropTags: vu, iter, url
+
+	// Custom tags (testid) are kept automatically; high-cardinality vu/url and
+	// internal tags (expected_response/status) are dropped.
+	t1 := a.groupTags(map[string]string{
+		"name": "GET /x", "group": "g1", "testid": "t1",
+		"vu": "1", "url": "http://a/x", "expected_response": "true", "status": "200",
+	})
+	assert.Equal(t, "GET /x", t1["name"])
+	assert.Equal(t, "g1", t1["group"])
+	assert.Equal(t, "t1", t1["testid"], "custom tag kept with no extra config")
+	assert.NotContains(t, t1, "vu")
+	assert.NotContains(t, t1, "url")
+	assert.NotContains(t, t1, "expected_response")
+	assert.NotContains(t, t1, "status")
+
+	// Same grouping tags but different vu/url => same key.
+	t2 := a.groupTags(map[string]string{
+		"name": "GET /x", "group": "g1", "testid": "t1", "vu": "99", "url": "http://a/x?z=2",
+	})
+	assert.Equal(t, groupKey(t1), groupKey(t2), "vu/url must not affect the group key")
+
+	// Different custom tag value => different key.
+	t3 := a.groupTags(map[string]string{"name": "GET /x", "group": "g1", "testid": "t2"})
+	assert.NotEqual(t, groupKey(t1), groupKey(t3))
+}
+
+func TestAggregatorIngest(t *testing.T) {
+	t.Parallel()
+
+	registry := metrics.NewRegistry()
+	dur, err := registry.NewMetric(metricHTTPReqDuration, metrics.Trend)
+	require.NoError(t, err)
+	sent, err := registry.NewMetric(metricDataSent, metrics.Counter)
+	require.NoError(t, err)
+	vus, err := registry.NewMetric(metricVUs, metrics.Gauge)
+	require.NoError(t, err)
+
+	mkSample := func(m *metrics.Metric, v float64, tags map[string]string) metrics.Sample {
+		return metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m,
+				Tags:   registry.RootTagSet().WithTagsFromMap(tags),
+			},
+			Value: v,
+		}
+	}
+
+	a := newAggregator(Config{Aggregation: AggregationConfig{Percentiles: []float64{95}}})
+
+	okTags := map[string]string{"name": "GET /x", "group": "g", "expected_response": "true", "status": "200"}
+	koTags := map[string]string{
+		"name": "GET /x", "group": "g", "expected_response": "false", "status": "500", "error": "boom",
+	}
+
+	a.ingest([]metrics.SampleContainer{metrics.Samples{
+		mkSample(dur, 100, okTags),
+		mkSample(dur, 200, okTags),
+		mkSample(dur, 500, koTags),
+		mkSample(sent, 1024, okTags),
+		mkSample(vus, 5, nil),
+		mkSample(vus, 9, nil),
+	}})
+
+	require.Len(t, a.groups, 1)
+	var m *samplerMetric
+	for _, g := range a.groups {
+		m = g
+	}
+	assert.Equal(t, int64(2), m.successes)
+	assert.Equal(t, int64(1), m.failures)
+	assert.Equal(t, int64(3), m.hits)
+	assert.Len(t, m.allValues, 3)
+	assert.Len(t, m.okValues, 2)
+	assert.Len(t, m.koValues, 1)
+	assert.Equal(t, int64(1), m.errors[errKey{status: "500", msg: "boom"}])
+	// Per-status-code counters track every code, including successful 2xx.
+	assert.Equal(t, int64(2), m.statusCounts["200"])
+	assert.Equal(t, int64(1), m.statusCounts["500"])
+	// data_sent is tracked as a global total, not per-group, and must not create a group.
+	assert.Equal(t, 1024.0, a.totalSent)
+	require.Len(t, a.groups, 1)
+
+	assert.Equal(t, 5.0, a.users.min)
+	assert.Equal(t, 9.0, a.users.max)
+	assert.Equal(t, int64(2), a.users.count)
+
+	// drain resets state.
+	snap := a.drain()
+	assert.Len(t, snap.groups, 1)
+	assert.Empty(t, a.groups)
+	assert.Equal(t, int64(0), a.users.count)
+}

--- a/pkg/influxdb/aggregator_test.go
+++ b/pkg/influxdb/aggregator_test.go
@@ -30,12 +30,20 @@ func TestPercentileField(t *testing.T) {
 	assert.Equal(t, "p99_9", percentileField(99.9))
 }
 
+func TestJMeterPercentileField(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "pct90.0", jmeterPercentileField(90))
+	assert.Equal(t, "pct95.0", jmeterPercentileField(95))
+	assert.Equal(t, "pct99.9", jmeterPercentileField(99.9))
+}
+
 func TestStatsFields(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
-		f := statsFields(nil, []float64{95})
+		f := statsFields(nil, []float64{95}, percentileField)
 		assert.Equal(t, int64(0), f["count"])
 		_, hasAvg := f["avg"]
 		assert.False(t, hasAvg)
@@ -43,13 +51,20 @@ func TestStatsFields(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		t.Parallel()
-		f := statsFields([]float64{10, 20, 30, 40}, []float64{90, 99})
+		f := statsFields([]float64{10, 20, 30, 40}, []float64{90, 99}, percentileField)
 		assert.Equal(t, int64(4), f["count"])
 		assert.InDelta(t, 10.0, f["min"], 1e-9)
 		assert.InDelta(t, 40.0, f["max"], 1e-9)
 		assert.InDelta(t, 25.0, f["avg"], 1e-9)
 		assert.Contains(t, f, "p90")
 		assert.Contains(t, f, "p99")
+	})
+
+	t.Run("jmeter field names", func(t *testing.T) {
+		t.Parallel()
+		f := statsFields([]float64{10, 20, 30, 40}, []float64{90, 99}, jmeterPercentileField)
+		assert.Contains(t, f, "pct90.0")
+		assert.Contains(t, f, "pct99.0")
 	})
 }
 
@@ -131,10 +146,10 @@ func TestAggregatorIngest(t *testing.T) {
 	assert.Len(t, m.allValues, 3)
 	assert.Len(t, m.okValues, 2)
 	assert.Len(t, m.koValues, 1)
-	assert.Equal(t, int64(1), m.errors[errKey{status: "500", msg: "boom"}])
-	// Per-status-code counters track every code, including successful 2xx.
-	assert.Equal(t, int64(2), m.statusCounts["200"])
-	assert.Equal(t, int64(1), m.statusCounts["500"])
+	// Per-(status,message) counters track every response, including successful 2xx,
+	// with a synthetic "OK" message for successes (mirroring JMeter's own rows).
+	assert.Equal(t, int64(2), m.statusCounts[errKey{status: "200", msg: okMessage}])
+	assert.Equal(t, int64(1), m.statusCounts[errKey{status: "500", msg: "boom"}])
 	// data_sent is tracked as a global total, not per-group, and must not create a group.
 	assert.Equal(t, 1024.0, a.totalSent)
 	require.Len(t, a.groups, 1)

--- a/pkg/influxdb/config.go
+++ b/pkg/influxdb/config.go
@@ -22,6 +22,29 @@ type Config struct {
 	ConcurrentWrites      null.Int           `json:"concurrentWrites" envconfig:"K6_INFLUXDB_CONCURRENT_WRITES"`
 	Precision             types.NullDuration `json:"precision" envconfig:"K6_INFLUXDB_PRECISION"`
 	TagsAsFields          []string           `json:"tagsAsFields,omitempty" envconfig:"K6_INFLUXDB_TAGS_AS_FIELDS"`
+
+	// Aggregation holds the optional JMeter-style aggregation settings. When
+	// disabled (the default) the output sends raw per-sample points unchanged.
+	Aggregation AggregationConfig `json:"aggregation"`
+}
+
+// AggregationConfig contains the optional JMeter-style metric aggregation
+// settings. When Enabled is false (the default), the output keeps its original
+// raw per-sample behavior. When true, samples are aggregated over a time window
+// and only summary points are written, drastically reducing the load on InfluxDB.
+type AggregationConfig struct {
+	// Enabled turns aggregation on. Default false (raw per-sample output).
+	Enabled null.Bool `json:"enabled" envconfig:"K6_INFLUXDB_AGGREGATION_ENABLED"`
+	// FlushInterval is how often aggregated summaries are written. Default 5s.
+	FlushInterval types.NullDuration `json:"flushInterval" envconfig:"K6_INFLUXDB_AGGREGATION_FLUSH_INTERVAL"`
+	// Measurement is the InfluxDB measurement name for aggregated points.
+	Measurement null.String `json:"measurement" envconfig:"K6_INFLUXDB_AGGREGATION_MEASUREMENT"`
+	// Percentiles is the list of response-time percentiles to compute (e.g. 90, 95, 99).
+	Percentiles []float64 `json:"percentiles,omitempty" envconfig:"K6_INFLUXDB_AGGREGATION_PERCENTILES"`
+	// DropTags is the denylist of high-cardinality tags that are excluded from the
+	// aggregation grouping. Every other tag (built-in or custom) is kept automatically.
+	// Defaults to vu, iter and url.
+	DropTags []string `json:"dropTags,omitempty" envconfig:"K6_INFLUXDB_AGGREGATION_DROP_TAGS"`
 }
 
 // NewConfig creates a new InfluxDB output config with some default values.
@@ -31,6 +54,13 @@ func NewConfig() Config {
 		TagsAsFields:     []string{"vu:int", "iter:int", "url"},
 		ConcurrentWrites: null.NewInt(4, false),
 		PushInterval:     types.NewNullDuration(time.Second, false),
+		Aggregation: AggregationConfig{
+			Enabled:       null.NewBool(false, false),
+			FlushInterval: types.NewNullDuration(5*time.Second, false),
+			Measurement:   null.NewString("k6_aggregated", false),
+			Percentiles:   []float64{90, 95, 99},
+			DropTags:      []string{"vu", "iter", "url"},
+		},
 	}
 	return c
 }
@@ -63,6 +93,21 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.Precision.Valid {
 		c.Precision = cfg.Precision
+	}
+	if cfg.Aggregation.Enabled.Valid {
+		c.Aggregation.Enabled = cfg.Aggregation.Enabled
+	}
+	if cfg.Aggregation.FlushInterval.Valid {
+		c.Aggregation.FlushInterval = cfg.Aggregation.FlushInterval
+	}
+	if cfg.Aggregation.Measurement.Valid {
+		c.Aggregation.Measurement = cfg.Aggregation.Measurement
+	}
+	if len(cfg.Aggregation.Percentiles) > 0 {
+		c.Aggregation.Percentiles = cfg.Aggregation.Percentiles
+	}
+	if len(cfg.Aggregation.DropTags) > 0 {
+		c.Aggregation.DropTags = cfg.Aggregation.DropTags
 	}
 	return c
 }

--- a/pkg/influxdb/config.go
+++ b/pkg/influxdb/config.go
@@ -45,6 +45,12 @@ type AggregationConfig struct {
 	// aggregation grouping. Every other tag (built-in or custom) is kept automatically.
 	// Defaults to vu, iter and url.
 	DropTags []string `json:"dropTags,omitempty" envconfig:"K6_INFLUXDB_AGGREGATION_DROP_TAGS"`
+	// Schema selects the tag/field naming scheme for aggregated points: "k6" (default)
+	// keeps this output's own naming, "jmeter" mirrors a real JMeter InfluxDB backend
+	// listener's schema so existing JMeter dashboards/queries can be reused. Tags like
+	// JMeter's "application"/"testTitle" are not modeled separately here -- set them as
+	// k6 global tags (options.tags) and they'll flow through like any other custom tag.
+	Schema null.String `json:"schema" envconfig:"K6_INFLUXDB_AGGREGATION_SCHEMA"`
 }
 
 // NewConfig creates a new InfluxDB output config with some default values.
@@ -60,6 +66,7 @@ func NewConfig() Config {
 			Measurement:   null.NewString("k6_aggregated", false),
 			Percentiles:   []float64{90, 95, 99},
 			DropTags:      []string{"vu", "iter", "url"},
+			Schema:        null.NewString("k6", false),
 		},
 	}
 	return c
@@ -108,6 +115,9 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if len(cfg.Aggregation.DropTags) > 0 {
 		c.Aggregation.DropTags = cfg.Aggregation.DropTags
+	}
+	if cfg.Aggregation.Schema.Valid {
+		c.Aggregation.Schema = cfg.Aggregation.Schema
 	}
 	return c
 }

--- a/pkg/influxdb/config_test.go
+++ b/pkg/influxdb/config_test.go
@@ -69,13 +69,14 @@ func TestAggregationConfigDefaults(t *testing.T) {
 	assert.Equal(t, "k6_aggregated", c.Aggregation.Measurement.String)
 	assert.Equal(t, []float64{90, 95, 99}, c.Aggregation.Percentiles)
 	assert.Equal(t, []string{"vu", "iter", "url"}, c.Aggregation.DropTags)
+	assert.Equal(t, "k6", c.Aggregation.Schema.String)
 }
 
 func TestAggregationConfigFromJSON(t *testing.T) {
 	t.Parallel()
 
 	json := []byte(`{"aggregation":{"enabled":true,"flushInterval":"10s",` +
-		`"measurement":"perf","percentiles":[50,90,99],"dropTags":["vu","iter","url","ip"]}}`)
+		`"measurement":"perf","percentiles":[50,90,99],"dropTags":["vu","iter","url","ip"],"schema":"jmeter"}}`)
 	c, err := GetConsolidatedConfig(json, nil, "")
 	assert.NoError(t, err)
 	assert.True(t, c.Aggregation.Enabled.Bool)
@@ -83,6 +84,7 @@ func TestAggregationConfigFromJSON(t *testing.T) {
 	assert.Equal(t, "perf", c.Aggregation.Measurement.String)
 	assert.Equal(t, []float64{50, 90, 99}, c.Aggregation.Percentiles)
 	assert.Equal(t, []string{"vu", "iter", "url", "ip"}, c.Aggregation.DropTags)
+	assert.Equal(t, "jmeter", c.Aggregation.Schema.String)
 }
 
 func TestAggregationConfigFromEnv(t *testing.T) {
@@ -94,6 +96,7 @@ func TestAggregationConfigFromEnv(t *testing.T) {
 		"K6_INFLUXDB_AGGREGATION_MEASUREMENT":    "perf_env",
 		"K6_INFLUXDB_AGGREGATION_PERCENTILES":    "50,90,99",
 		"K6_INFLUXDB_AGGREGATION_DROP_TAGS":      "vu,iter,url,ip",
+		"K6_INFLUXDB_AGGREGATION_SCHEMA":         "jmeter",
 	}
 	c, err := GetConsolidatedConfig(nil, env, "")
 	assert.NoError(t, err)
@@ -102,4 +105,18 @@ func TestAggregationConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "perf_env", c.Aggregation.Measurement.String)
 	assert.Equal(t, []float64{50, 90, 99}, c.Aggregation.Percentiles)
 	assert.Equal(t, []string{"vu", "iter", "url", "ip"}, c.Aggregation.DropTags)
+	assert.Equal(t, "jmeter", c.Aggregation.Schema.String)
+}
+
+func TestValidateAggregationSchema(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateAggregation(NewConfig()))
+
+	c := NewConfig()
+	c.Aggregation.Schema = null.StringFrom("jmeter")
+	assert.NoError(t, validateAggregation(c))
+
+	c.Aggregation.Schema = null.StringFrom("bogus")
+	assert.Error(t, validateAggregation(c))
 }

--- a/pkg/influxdb/config_test.go
+++ b/pkg/influxdb/config_test.go
@@ -58,3 +58,48 @@ func TestGetConsolidatedConfig(t *testing.T) {
 	assert.Equal(t, types.NullDurationFrom(duration999s), check.Precision)
 	assert.Equal(t, []string{"test-tag-1", "test-tag-2", "test-tag-3"}, check.TagsAsFields)
 }
+
+func TestAggregationConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	c, err := GetConsolidatedConfig(nil, nil, "")
+	assert.NoError(t, err)
+	assert.False(t, c.Aggregation.Enabled.Bool)
+	assert.Equal(t, 5*time.Second, time.Duration(c.Aggregation.FlushInterval.Duration))
+	assert.Equal(t, "k6_aggregated", c.Aggregation.Measurement.String)
+	assert.Equal(t, []float64{90, 95, 99}, c.Aggregation.Percentiles)
+	assert.Equal(t, []string{"vu", "iter", "url"}, c.Aggregation.DropTags)
+}
+
+func TestAggregationConfigFromJSON(t *testing.T) {
+	t.Parallel()
+
+	json := []byte(`{"aggregation":{"enabled":true,"flushInterval":"10s",` +
+		`"measurement":"perf","percentiles":[50,90,99],"dropTags":["vu","iter","url","ip"]}}`)
+	c, err := GetConsolidatedConfig(json, nil, "")
+	assert.NoError(t, err)
+	assert.True(t, c.Aggregation.Enabled.Bool)
+	assert.Equal(t, types.NullDurationFrom(10*time.Second), c.Aggregation.FlushInterval)
+	assert.Equal(t, "perf", c.Aggregation.Measurement.String)
+	assert.Equal(t, []float64{50, 90, 99}, c.Aggregation.Percentiles)
+	assert.Equal(t, []string{"vu", "iter", "url", "ip"}, c.Aggregation.DropTags)
+}
+
+func TestAggregationConfigFromEnv(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"K6_INFLUXDB_AGGREGATION_ENABLED":        "true",
+		"K6_INFLUXDB_AGGREGATION_FLUSH_INTERVAL": "3s",
+		"K6_INFLUXDB_AGGREGATION_MEASUREMENT":    "perf_env",
+		"K6_INFLUXDB_AGGREGATION_PERCENTILES":    "50,90,99",
+		"K6_INFLUXDB_AGGREGATION_DROP_TAGS":      "vu,iter,url,ip",
+	}
+	c, err := GetConsolidatedConfig(nil, env, "")
+	assert.NoError(t, err)
+	assert.True(t, c.Aggregation.Enabled.Bool)
+	assert.Equal(t, types.NullDurationFrom(3*time.Second), c.Aggregation.FlushInterval)
+	assert.Equal(t, "perf_env", c.Aggregation.Measurement.String)
+	assert.Equal(t, []float64{50, 90, 99}, c.Aggregation.Percentiles)
+	assert.Equal(t, []string{"vu", "iter", "url", "ip"}, c.Aggregation.DropTags)
+}

--- a/pkg/influxdb/output.go
+++ b/pkg/influxdb/output.go
@@ -55,6 +55,11 @@ type Output struct {
 	pointWriter     api.WriteAPIBlocking
 	semaphoreCh     chan struct{}
 	wg              sync.WaitGroup
+
+	// aggregator and aggFlusher are non-nil only when aggregation is enabled.
+	// When enabled, the raw per-sample path is replaced by JMeter-style aggregation.
+	aggregator *aggregator
+	aggFlusher *output.PeriodicFlusher
 }
 
 // New returns new InfluxDB Output
@@ -83,7 +88,7 @@ func New(params output.Params) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Output{
+	o := &Output{
 		params:      params,
 		logger:      logger,
 		client:      cl,
@@ -92,7 +97,27 @@ func New(params output.Params) (*Output, error) {
 		pointWriter: cl.WriteAPIBlocking(conf.Organization.String, conf.Bucket.String),
 		semaphoreCh: make(chan struct{}, conf.ConcurrentWrites.Int64),
 		wg:          sync.WaitGroup{},
-	}, nil
+	}
+	if conf.Aggregation.Enabled.Bool {
+		if err := validateAggregation(conf); err != nil {
+			return nil, err
+		}
+		o.aggregator = newAggregator(conf)
+		logger.WithField("flushInterval", time.Duration(conf.Aggregation.FlushInterval.Duration)).
+			Info("InfluxDB aggregation enabled: sending JMeter-style aggregated metrics")
+	}
+	return o, nil
+}
+
+// validateAggregation checks aggregation options. It only runs when aggregation
+// is enabled, so the default raw path gains no new failure modes.
+func validateAggregation(conf Config) error {
+	for _, p := range conf.Aggregation.Percentiles {
+		if p <= 0 || p >= 100 {
+			return fmt.Errorf("the aggregation percentile %v must be between 0 and 100 (exclusive)", p)
+		}
+	}
+	return nil
 }
 
 // Description returns a human-readable description of the output.
@@ -107,17 +132,39 @@ func (o *Output) Start() error {
 	if err != nil {
 		return err
 	}
-	o.logger.Debug("Started")
 	o.periodicFlusher = pf
+
+	// When aggregation is enabled, flushMetrics only drains the buffer into the
+	// aggregator; a separate, slower flusher emits the aggregated summaries.
+	if o.aggregator != nil {
+		apf, err := output.NewPeriodicFlusher(
+			time.Duration(o.config.Aggregation.FlushInterval.Duration), o.flushAggregated)
+		if err != nil {
+			// Don't leave the buffer flusher running if the aggregation flusher
+			// failed to start.
+			o.periodicFlusher.Stop()
+			return err
+		}
+		o.aggFlusher = apf
+	}
+
+	o.logger.Debug("Started")
 	return nil
 }
 
-// Stop flushes any remaining metrics and stops the goroutine.
+// Stop flushes any remaining metrics and stops the goroutines.
 func (o *Output) Stop() error {
 	o.logger.Debug("Stopping...")
+	// Stop the buffer flusher first so no new samples are ingested, then flush
+	// the final aggregation window (PeriodicFlusher.Stop runs the callback once more).
 	o.periodicFlusher.Stop()
-	o.client.Close()
+	if o.aggFlusher != nil {
+		o.aggFlusher.Stop()
+	}
+	// Wait for every in-flight write to finish before closing the client, so the
+	// final flush (raw or aggregated) is never cut off mid-request.
 	o.wg.Wait()
+	o.client.Close()
 	o.logger.Debug("Stopped")
 	return nil
 }
@@ -189,6 +236,13 @@ func (o *Output) flushMetrics() {
 		return
 	}
 
+	// Aggregation path: fold samples into the rolling state in memory (no network
+	// I/O here). The aggregated summaries are written by flushAggregated.
+	if o.aggregator != nil {
+		o.aggregator.ingest(samples)
+		return
+	}
+
 	o.wg.Add(1)
 	o.semaphoreCh <- struct{}{}
 	go func() {
@@ -218,6 +272,128 @@ func (o *Output) flushMetrics() {
 			o.logger.WithField("t", d).Warn(msg)
 		}
 	}()
+}
+
+// flushAggregated drains the current aggregation window and writes the JMeter-style
+// summary points. It mirrors flushMetrics' goroutine/semaphore structure.
+func (o *Output) flushAggregated() {
+	snap := o.aggregator.drain()
+	if len(snap.groups) == 0 && snap.users.count == 0 && snap.totalSent == 0 && snap.totalReceived == 0 {
+		return
+	}
+
+	o.wg.Add(1)
+	o.semaphoreCh <- struct{}{}
+	go func() {
+		defer func() {
+			<-o.semaphoreCh
+			o.wg.Done()
+		}()
+
+		start := time.Now()
+		batch := aggregateBatch(snap, start)
+
+		o.logger.WithField("points", len(batch)).Debug("Sending aggregated points...")
+		if err := o.pointWriter.WritePoint(context.Background(), batch...); err != nil {
+			o.logger.WithError(err).
+				WithField("elapsed", time.Since(start)).
+				WithField("points", len(batch)).
+				Error("Couldn't send aggregated points")
+			return
+		}
+		o.logger.WithField("elapsed", time.Since(start)).Debug("Aggregated points have been sent")
+	}()
+}
+
+// aggregateBatch turns a drained aggregation window into InfluxDB points,
+// replicating JMeter's schema: per (name, group) an ok/ko/all triple, per-error
+// rows, a cumulative "all" rollup, and an "internal" thread-metrics row.
+func aggregateBatch(snap aggSnapshot, ts time.Time) []*write.Point {
+	var points []*write.Point
+	var totalErrors int64
+	// globalValues collects every response time across all groups so the cumulative
+	// "all" row can report exact run-wide stats/percentiles (averaging per-group
+	// percentiles would be statistically wrong).
+	var globalValues []float64
+
+	for _, m := range snap.groups {
+		resultValues := []struct {
+			result string
+			values []float64
+		}{
+			{statusOK, m.okValues},
+			{statusKO, m.koValues},
+			{statusAll, m.allValues},
+		}
+		for _, rv := range resultValues {
+			// Always emit the "all" row; skip empty ok/ko rows.
+			if len(rv.values) == 0 && rv.result != statusAll {
+				continue
+			}
+			fields := statsFields(rv.values, snap.percentiles)
+			fields["hits"] = m.hits
+
+			tags := copyTags(m.tags)
+			tags[tagResult] = rv.result
+			points = append(points, influxdbclient.NewPoint(snap.measurement, tags, fields, ts))
+		}
+
+		// Per-error breakdown (response code + message), like JMeter's error metrics.
+		for ek, c := range m.errors {
+			tags := copyTags(m.tags)
+			tags[tagResult] = statusKO
+			tags[tagStatus] = ek.status
+			tags[tagError] = ek.msg
+			points = append(points, influxdbclient.NewPoint(
+				snap.measurement, tags, map[string]any{"errors": c}, ts))
+		}
+
+		// Per-HTTP-status-code counts (result=status), including successful 2xx.
+		// Count-only rows: counts are additive across windows, so a response-code
+		// distribution charts correctly at any time range (unlike percentiles).
+		for status, c := range m.statusCounts {
+			tags := copyTags(m.tags)
+			tags[tagResult] = resultStatusCount
+			tags[tagStatus] = status
+			points = append(points, influxdbclient.NewPoint(
+				snap.measurement, tags, map[string]any{"count": c}, ts))
+		}
+
+		globalValues = append(globalValues, m.allValues...)
+		totalErrors += m.failures
+	}
+
+	// Cumulative "all" transaction across every group: exact run-wide
+	// count/avg/min/max/percentiles plus errors. data_sent/data_received are
+	// reported here as global totals since k6 measures them at the connection
+	// level and they cannot be attributed to individual requests.
+	cumulative := statsFields(globalValues, snap.percentiles)
+	cumulative["hits"] = int64(len(globalValues))
+	cumulative["errors"] = totalErrors
+	cumulative["data_sent"] = snap.totalSent
+	cumulative["data_received"] = snap.totalReceived
+	points = append(points, influxdbclient.NewPoint(
+		snap.measurement,
+		map[string]string{tagName: statusAll, tagResult: statusAll, "group": statusAll},
+		cumulative,
+		ts,
+	))
+
+	// Thread / active-VU metrics, like JMeter's "internal" transaction row.
+	if snap.users.count > 0 {
+		points = append(points, influxdbclient.NewPoint(
+			snap.measurement,
+			map[string]string{tagName: "internal", "group": "internal"},
+			map[string]any{
+				"vus_min":  snap.users.min,
+				"vus_max":  snap.users.max,
+				"vus_mean": snap.users.sum / float64(snap.users.count),
+			},
+			ts,
+		))
+	}
+
+	return points
 }
 
 // MakeFieldKinds reads the Config and returns a lookup map of tag names to

--- a/pkg/influxdb/output.go
+++ b/pkg/influxdb/output.go
@@ -117,6 +117,12 @@ func validateAggregation(conf Config) error {
 			return fmt.Errorf("the aggregation percentile %v must be between 0 and 100 (exclusive)", p)
 		}
 	}
+	switch conf.Aggregation.Schema.String {
+	case "", schemaK6, schemaJMeter:
+	default:
+		return fmt.Errorf("the aggregation schema %q must be %q or %q",
+			conf.Aggregation.Schema.String, schemaK6, schemaJMeter)
+	}
 	return nil
 }
 
@@ -305,10 +311,50 @@ func (o *Output) flushAggregated() {
 	}()
 }
 
-// aggregateBatch turns a drained aggregation window into InfluxDB points,
-// replicating JMeter's schema: per (name, group) an ok/ko/all triple, per-error
-// rows, a cumulative "all" rollup, and an "internal" thread-metrics row.
+// baseTags returns schema's tag map for one sampler group's raw grouping tags
+// (name, group, and any pass-through custom tags), per schema.combineTransaction/
+// transactionTag/droppedTags.
+func baseTags(schema schemaDef, tags map[string]string) map[string]string {
+	if !schema.combineTransaction {
+		return copyTags(tags)
+	}
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		if k == tagName || k == tagGroup || schema.droppedTags[k] {
+			continue
+		}
+		out[k] = v
+	}
+	name, group := tags[tagName], tags[tagGroup]
+	switch {
+	case group != "" && name != "":
+		out[schema.transactionTag] = group + "::" + name
+	case group != "":
+		out[schema.transactionTag] = group
+	default:
+		out[schema.transactionTag] = name
+	}
+	return out
+}
+
+// sentinelTransactionTags returns schema's tag map for a synthetic,
+// non-sample-derived row (the cumulative "all" rollup or the "internal"
+// thread-metrics row).
+func sentinelTransactionTags(schema schemaDef, name string) map[string]string {
+	if schema.combineTransaction {
+		return map[string]string{schema.transactionTag: name}
+	}
+	return map[string]string{tagName: name, tagGroup: name}
+}
+
+// aggregateBatch turns a drained aggregation window into InfluxDB points, per
+// the active schema: per transaction an ok/ko/all triple, per-response-code
+// count rows, a cumulative "all" rollup, and an "internal" thread-metrics row.
+// rb/sb (per-request byte counts) and startedT/endedT (threads started/ended
+// per interval) are never emitted -- k6 has no equivalent per-request data.
 func aggregateBatch(snap aggSnapshot, ts time.Time) []*write.Point {
+	schema := schemaFor(snap.schema)
+
 	var points []*write.Point
 	var totalErrors int64
 	// globalValues collects every response time across all groups so the cumulative
@@ -330,31 +376,24 @@ func aggregateBatch(snap aggSnapshot, ts time.Time) []*write.Point {
 			if len(rv.values) == 0 && rv.result != statusAll {
 				continue
 			}
-			fields := statsFields(rv.values, snap.percentiles)
-			fields["hits"] = m.hits
+			fields := statsFields(rv.values, snap.percentiles, schema.percentileField)
+			fields[schema.hitField] = m.hits
 
-			tags := copyTags(m.tags)
+			tags := baseTags(schema, m.tags)
 			tags[tagResult] = rv.result
 			points = append(points, influxdbclient.NewPoint(snap.measurement, tags, fields, ts))
 		}
 
-		// Per-error breakdown (response code + message), like JMeter's error metrics.
-		for ek, c := range m.errors {
-			tags := copyTags(m.tags)
-			tags[tagResult] = statusKO
-			tags[tagStatus] = ek.status
-			tags[tagError] = ek.msg
-			points = append(points, influxdbclient.NewPoint(
-				snap.measurement, tags, map[string]any{"errors": c}, ts))
-		}
-
-		// Per-HTTP-status-code counts (result=status), including successful 2xx.
+		// Per-response-code counts, including successful 2xx -- mirrors JMeter's
+		// own per-response-code rows, which carry no ok/ko/all (statut) tag.
 		// Count-only rows: counts are additive across windows, so a response-code
 		// distribution charts correctly at any time range (unlike percentiles).
-		for status, c := range m.statusCounts {
-			tags := copyTags(m.tags)
-			tags[tagResult] = resultStatusCount
-			tags[tagStatus] = status
+		for ek, c := range m.statusCounts {
+			tags := baseTags(schema, m.tags)
+			tags[schema.responseCodeTag] = ek.status
+			if !schema.omitSuccessMessage || ek.msg != okMessage {
+				tags[schema.responseMessageTag] = ek.msg
+			}
 			points = append(points, influxdbclient.NewPoint(
 				snap.measurement, tags, map[string]any{"count": c}, ts))
 		}
@@ -366,28 +405,28 @@ func aggregateBatch(snap aggSnapshot, ts time.Time) []*write.Point {
 	// Cumulative "all" transaction across every group: exact run-wide
 	// count/avg/min/max/percentiles plus errors. data_sent/data_received are
 	// reported here as global totals since k6 measures them at the connection
-	// level and they cannot be attributed to individual requests.
-	cumulative := statsFields(globalValues, snap.percentiles)
-	cumulative["hits"] = int64(len(globalValues))
-	cumulative["errors"] = totalErrors
-	cumulative["data_sent"] = snap.totalSent
-	cumulative["data_received"] = snap.totalReceived
-	points = append(points, influxdbclient.NewPoint(
-		snap.measurement,
-		map[string]string{tagName: statusAll, tagResult: statusAll, "group": statusAll},
-		cumulative,
-		ts,
-	))
+	// level and cannot be attributed to individual requests; they have no JMeter
+	// equivalent, so schema.includeConnectionTotals is false in jmeter schema.
+	cumulative := statsFields(globalValues, snap.percentiles, schema.percentileField)
+	cumulative[schema.hitField] = int64(len(globalValues))
+	cumulative[schema.countErrorField] = totalErrors
+	if schema.includeConnectionTotals {
+		cumulative["data_sent"] = snap.totalSent
+		cumulative["data_received"] = snap.totalReceived
+	}
+	cumulativeTags := sentinelTransactionTags(schema, statusAll)
+	cumulativeTags[tagResult] = statusAll
+	points = append(points, influxdbclient.NewPoint(snap.measurement, cumulativeTags, cumulative, ts))
 
 	// Thread / active-VU metrics, like JMeter's "internal" transaction row.
 	if snap.users.count > 0 {
 		points = append(points, influxdbclient.NewPoint(
 			snap.measurement,
-			map[string]string{tagName: "internal", "group": "internal"},
+			sentinelTransactionTags(schema, "internal"),
 			map[string]any{
-				"vus_min":  snap.users.min,
-				"vus_max":  snap.users.max,
-				"vus_mean": snap.users.sum / float64(snap.users.count),
+				schema.minActiveField:  snap.users.min,
+				schema.maxActiveField:  snap.users.max,
+				schema.meanActiveField: snap.users.sum / float64(snap.users.count),
 			},
 			ts,
 		))

--- a/pkg/influxdb/output_test.go
+++ b/pkg/influxdb/output_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -141,6 +142,101 @@ func TestOutputFlushMetrics(t *testing.T) {
 		c.AddMetricSamples([]metrics.SampleContainer{samples})
 		c.AddMetricSamples([]metrics.SampleContainer{samples})
 	})
+}
+
+func TestAggregationDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var body string
+	registry := metrics.NewRegistry()
+
+	testOutputCycle(t, func(rw http.ResponseWriter, r *http.Request) {
+		b := bytes.NewBuffer(nil)
+		_, _ = io.Copy(b, r.Body)
+		mu.Lock()
+		body += b.String()
+		mu.Unlock()
+		rw.WriteHeader(http.StatusNoContent)
+	}, func(tb testing.TB, c *Output) {
+		require.Nil(tb, c.aggregator, "aggregation must be off by default")
+		metric, err := registry.NewMetric("http_req_duration", metrics.Trend)
+		require.NoError(tb, err)
+		c.AddMetricSamples([]metrics.SampleContainer{metrics.Samples{{
+			TimeSeries: metrics.TimeSeries{
+				Metric: metric,
+				Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"name": "GET /x"}),
+			},
+			Time:  time.Now(),
+			Value: 1.0,
+		}}})
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, body, "http_req_duration", "raw per-sample measurement expected")
+	assert.NotContains(t, body, "k6_aggregated", "no aggregated measurement when disabled")
+}
+
+func TestOutputAggregated(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var body string
+	registry := metrics.NewRegistry()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		b := bytes.NewBuffer(nil)
+		_, _ = io.Copy(b, r.Body)
+		mu.Lock()
+		body += b.String()
+		mu.Unlock()
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c, err := New(output.Params{
+		Logger:         logrus.New(),
+		ConfigArgument: fmt.Sprintf("%s/testbucket", ts.URL),
+		JSONConfig: json.RawMessage(
+			`{"aggregation":{"enabled":true,"flushInterval":"50ms","percentiles":[95,99]}}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c.aggregator)
+	require.NoError(t, c.Start())
+
+	dur, err := registry.NewMetric("http_req_duration", metrics.Trend)
+	require.NoError(t, err)
+
+	mkSample := func(v float64, tags map[string]string) metrics.Sample {
+		return metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: dur,
+				Tags:   registry.RootTagSet().WithTagsFromMap(tags),
+			},
+			Time:  time.Now(),
+			Value: v,
+		}
+	}
+	c.AddMetricSamples([]metrics.SampleContainer{metrics.Samples{
+		mkSample(100, map[string]string{"name": "GET /x", "group": "g", "testid": "run1", "vu": "1", "expected_response": "true"}),
+		mkSample(200, map[string]string{"name": "GET /x", "group": "g", "testid": "run1", "vu": "2", "expected_response": "true"}),
+		mkSample(500, map[string]string{"name": "GET /x", "group": "g", "testid": "run1", "vu": "3", "expected_response": "false", "status": "500"}),
+	}})
+
+	require.NoError(t, c.Stop()) // Stop flushes the final window and waits for writes.
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, body, "k6_aggregated", "aggregated measurement expected")
+	assert.Contains(t, body, "result=ok")
+	assert.Contains(t, body, "result=ko")
+	assert.Contains(t, body, "result=all")
+	assert.Contains(t, body, "name=all", "cumulative rollup row emitted")
+	assert.Contains(t, body, "name=GET", "transaction name carried as tag")
+	assert.Contains(t, body, "testid=run1", "custom tag carried automatically (no extraTags config)")
+	assert.Contains(t, body, "p95")
+	assert.NotContains(t, body, "vu=", "high-cardinality vu tag must be dropped")
 }
 
 func TestMakeFieldKinds(t *testing.T) {

--- a/pkg/influxdb/output_test.go
+++ b/pkg/influxdb/output_test.go
@@ -229,14 +229,92 @@ func TestOutputAggregated(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Contains(t, body, "k6_aggregated", "aggregated measurement expected")
-	assert.Contains(t, body, "result=ok")
-	assert.Contains(t, body, "result=ko")
-	assert.Contains(t, body, "result=all")
+	assert.Contains(t, body, "statut=ok")
+	assert.Contains(t, body, "statut=ko")
+	assert.Contains(t, body, "statut=all")
 	assert.Contains(t, body, "name=all", "cumulative rollup row emitted")
 	assert.Contains(t, body, "name=GET", "transaction name carried as tag")
 	assert.Contains(t, body, "testid=run1", "custom tag carried automatically (no extraTags config)")
 	assert.Contains(t, body, "p95")
+	assert.Contains(t, body, "countError", "cumulative row reports total errors")
 	assert.NotContains(t, body, "vu=", "high-cardinality vu tag must be dropped")
+}
+
+func TestOutputAggregatedJMeterSchema(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var body string
+	registry := metrics.NewRegistry()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		b := bytes.NewBuffer(nil)
+		_, _ = io.Copy(b, r.Body)
+		mu.Lock()
+		body += b.String()
+		mu.Unlock()
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c, err := New(output.Params{
+		Logger:         logrus.New(),
+		ConfigArgument: fmt.Sprintf("%s/testbucket", ts.URL),
+		JSONConfig: json.RawMessage(
+			`{"aggregation":{"enabled":true,"flushInterval":"50ms","percentiles":[90],"schema":"jmeter"}}`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.Start())
+
+	dur, err := registry.NewMetric("http_req_duration", metrics.Trend)
+	require.NoError(t, err)
+	vus, err := registry.NewMetric("vus", metrics.Gauge)
+	require.NoError(t, err)
+
+	mkSample := func(m *metrics.Metric, v float64, tags map[string]string) metrics.Sample {
+		return metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m,
+				Tags:   registry.RootTagSet().WithTagsFromMap(tags),
+			},
+			Time:  time.Now(),
+			Value: v,
+		}
+	}
+	c.AddMetricSamples([]metrics.SampleContainer{metrics.Samples{
+		mkSample(dur, 100, map[string]string{
+			"name": "GET /x", "group": "g", "application": "ELEARN", "method": "GET",
+			"proto": "HTTP/1.1", "tls_version": "tls1.3", "scenario": "default",
+			"expected_response": "true",
+		}),
+		mkSample(dur, 500, map[string]string{
+			"name": "GET /x", "group": "g", "application": "ELEARN",
+			"expected_response": "false", "status": "500", "error": "boom",
+		}),
+		mkSample(vus, 3, nil),
+	}})
+
+	require.NoError(t, c.Stop()) // Stop flushes the final window and waits for writes.
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, body, "transaction=g::GET", "group+name combined into transaction")
+	assert.NotContains(t, body, "name=GET", "no separate name tag in jmeter schema")
+	assert.NotContains(t, body, ",group=g", "no separate group tag in jmeter schema")
+	assert.Contains(t, body, "hit=", "hit field, not hits")
+	assert.NotContains(t, body, "hits=")
+	assert.Contains(t, body, "pct90.0", "jmeter-style percentile field name")
+	assert.Contains(t, body, "responseCode=500")
+	assert.Contains(t, body, "responseMessage=boom", "responseMessage is a tag, not a quoted field value")
+	assert.Contains(t, body, "application=ELEARN", "custom tag still passes through")
+	assert.NotContains(t, body, "method=", "k6-only tag dropped in jmeter schema")
+	assert.NotContains(t, body, "proto=", "k6-only tag dropped in jmeter schema")
+	assert.NotContains(t, body, "tls_version=", "k6-only tag dropped in jmeter schema")
+	assert.NotContains(t, body, "scenario=", "k6-only tag dropped in jmeter schema")
+	assert.Contains(t, body, "transaction=internal", "thread metrics stay a separate row")
+	assert.Contains(t, body, "minAT=")
+	assert.Contains(t, body, "maxAT=")
+	assert.Contains(t, body, "meanAT=")
 }
 
 func TestMakeFieldKinds(t *testing.T) {


### PR DESCRIPTION
Why this is needed
------------------
By default the output writes one InfluxDB point per metric sample. Under high load (high VU counts / high RPS) this produces an enormous volume of writes and series, which can overwhelm InfluxDB, balloon storage, and slow down dashboards -- the raw per-sample firehose becomes the bottleneck of the test rig rather than the system under test.

This adds an opt-in aggregation mode that buffers samples over a time window and writes compact JMeter-style summaries (count / avg / min / max / percentiles per request and group, split into ok/ko/all) instead of raw points. This drastically reduces the number of points written while keeping the signal that matters for performance analysis, mirroring the proven schema teams already know from JMeter's backend listener.

What it does
------------
- New AggregationConfig (enabled / flushInterval / measurement / percentiles / dropTags) consolidated from JSON, env (K6_INFLUXDB_AGGREGATION_*) and defaults. Off by default -- when disabled, behavior is byte-for-byte unchanged.
- aggregator.go: rolling aggregation state. Groups samples by full tag set (custom tags carried automatically; only a high-cardinality denylist of vu/iter/url is dropped), computes per-(name,group) ok/ko/all stats and percentiles, per-error and per-HTTP-status-code counts, a cumulative run-wide rollup, and active-VU metrics. Drained and reset every flushInterval.
- output.go: when enabled, the buffer flusher only folds samples into the aggregator (no network I/O); a separate, slower flusher emits the summaries reusing the existing goroutine/semaphore write path.
- Provisioned Grafana dashboard for the aggregated measurement + README docs.

Shutdown / robustness fixes
---------------------------
- Stop() now drains all in-flight writes (wg.Wait) BEFORE closing the client, so the final flush -- raw or aggregated -- is never cut off mid-request. This also closes a pre-existing race on the raw path.
- Start() stops the already-running buffer flusher if the aggregation flusher fails to construct, avoiding a leaked goroutine.

Tests
-----
- aggregator_test.go: quantile/percentile/stats math, tag grouping/key stability, full ingest+drain.
- config_test.go: aggregation defaults, JSON and env consolidation (incl. percentiles via env).
- output_test.go: aggregation off by default emits raw points; enabled emits the aggregated measurement with ok/ko/all rows, cumulative rollup, custom tags carried, and high-cardinality tags dropped.